### PR TITLE
Add getVersion()

### DIFF
--- a/examples/Further-OTA-Examples/Further-OTA-Examples.ino
+++ b/examples/Further-OTA-Examples/Further-OTA-Examples.ino
@@ -56,6 +56,11 @@ void setup()
 		.CheckForOTAUpdate(JSON_URL, VERSION, ESP32OTAPull::DONT_DO_UPDATE);
 	Serial.printf("CheckForOTAUpdate returned %d (%s)\n\n", ret, errtext(ret));
 
+	// After we've checked, we can obtain the version from the JSON file
+    String otaVersion = ota.getVersion();
+	Serial.print("OTA Version Available: ");
+	Serial.println(otaVersion);
+
 	delay(3000);
 
 	// Example 2

--- a/src/ESP32OTAPull.h
+++ b/src/ESP32OTAPull.h
@@ -36,7 +36,12 @@ class ESP32OTAPull
 public:
     enum ActionType { DONT_DO_UPDATE, UPDATE_BUT_NO_BOOT, UPDATE_AND_BOOT };
 
-    /// Return codes from CheckForOTAUpdate
+    String getVersion()
+    {
+        return CVersion;
+    }
+
+    // Return codes from CheckForOTAUpdate
     enum { UPDATE_AVAILABLE = -3, NO_UPDATE_PROFILE_FOUND = -2, NO_UPDATE_AVAILABLE = -1, UPDATE_OK = 0, HTTP_FAILED = 1, WRITE_ERROR = 2, JSON_PROBLEM = 3, OTA_UPDATE_FAIL = 4 };
 
 private:
@@ -45,6 +50,7 @@ private:
     String Board = ARDUINO_BOARD;
     String Device = "";
     String Config = "";
+    String CVersion = "";
     bool DowngradesAllowed = false;
 
     int DownloadJson(const char* URL, String& payload)
@@ -205,7 +211,7 @@ public:
         {
             String CBoard = config["Board"].isNull() ? "" : (const char *)config["Board"];
             String CDevice = config["Device"].isNull() ? "" : (const char *)config["Device"];
-            String CVersion = config["Version"].isNull() ? "" : (const char *)config["Version"];
+            CVersion = config["Version"].isNull() ? "" : (const char *)config["Version"];
             String CConfig = config["Config"].isNull() ? "" : (const char *)config["Config"];
             if ((CBoard.isEmpty() || CBoard == BoardName) &&
                 (CDevice.isEmpty() || CDevice == DeviceName) &&


### PR DESCRIPTION
This PR:

* Adds a helper to return the obtained version string from the JSON file.
* Adds to the further example demo'ing how to use getVersion().

I needed this so that I could [check the version](https://github.com/sparkfun/SparkFun_RTK_Firmware/blob/release_candidate/Firmware/RTK_Surveyor/menuFirmware.ino#L320) and show it to the user before they agreed to proceed with update.

It's an open question if other variables need to be exposed.

Love the library. Thanks for this! 

